### PR TITLE
Use strlen() instead of sizeof().

### DIFF
--- a/common/config.c
+++ b/common/config.c
@@ -651,7 +651,7 @@ int config_read(const char *name,
           goto parse_error;
         }
 
-        strncpy(g_config_port_name[port_counter - 1], port, sizeof(port));
+        strncpy(g_config_port_name[port_counter - 1], port, strlen(port) + 1);
       }
 
       continue;


### PR DESCRIPTION
Use strlen() instead of sizeof() in config_read() when copying port to g_config_port_name.